### PR TITLE
Refactor the reading logic as the API is inconsitent.

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/tarm/serial"
 	"log"
+	"strings"
 
-	"github.com/calvernaz/rak811"
+	"github.com/tarm/serial"
+
+	"github.com/krasi-georgiev/rak811"
 )
 
 func main() {
 	cfg := &serial.Config{
-		Name:        "/dev/ttyAMA0",
+		Name: "/dev/ttyAMA0",
 	}
 
 	lora, err := rak811.New(cfg)
@@ -27,6 +29,35 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to get version: ", err)
 	}
+	fmt.Printf("Version: %s\n", resp[2:])
 
-	fmt.Println(resp)
+	resp, err = lora.GetConfig("dev_eui")
+	if err != nil {
+		log.Fatal("failed get config: ", err)
+	}
+	fmt.Printf("DevEUI: %s\n", resp[2:])
+
+	resp, err = lora.SetConfig(fmt.Sprintf("dev_eui:%v", strings.ToLower(resp[2:])))
+	if err != nil {
+		log.Fatal("deveui err: ", err)
+	}
+	fmt.Printf("set devui: %v\n", resp)
+
+	resp, err = lora.SetConfig(fmt.Sprintf("app_eui:%v", "0000010000000000"))
+	if err != nil {
+		log.Fatal("appeui err: ", err)
+	}
+	fmt.Printf("set appeui: %v\n", resp)
+
+	resp, err = lora.SetConfig(fmt.Sprintf("app_key:%v", "09e714accc4450047ef24a6a59ac9a97"))
+	if err != nil {
+		log.Fatal("appkey err: ", err)
+	}
+	fmt.Printf("set appkey: %v\n", resp)
+
+	resp, err = lora.JoinOTAA()
+	if err != nil {
+		log.Fatal("failed to join: ", err)
+	}
+	fmt.Printf("Join: %s\n", resp)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
-module github.com/calvernaz/rak811
+module github.com/krasi-georgiev/rak811
 
 go 1.12
 
 require (
 	github.com/davecheney/gpio v0.0.0-20160912024957-a6de66e7e470
-	github.com/pkg/errors v0.8.1
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
-	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
+	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecheney/gpio v0.0.0-20160912024957-a6de66e7e470 h1:pw35WQPA7J4mJlRHfDlNdD5o3ykHpWGuwyLnT6kv1fU=
 github.com/davecheney/gpio v0.0.0-20160912024957-a6de66e7e470/go.mod h1:43PwoPhLiAtAufKfF2PL7uav7KfyIXgGKqlcXPpvMAo=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
-golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/rak811.go
+++ b/rak811.go
@@ -13,18 +13,19 @@ import (
 	"github.com/tarm/serial"
 )
 
-// ErrTimeout is returns when the serial port doesnt return any data
-// within the test ReadTimeout
-var ErrTimeout = errors.New("no response within the set timeout")
-
 const OK = "OK"
 
 type config func(*serial.Config)
 
 type Lora struct {
 	port io.ReadWriteCloser
+	// Returns an error when the global timeout argument expires.
+	// This is as a fail safe so that the caller can reset the module
+	// if it doesn't return anything for a long period.
+	timeout time.Duration
 }
 
+// New sets the lora module configuration.
 func New(conf *serial.Config) (*Lora, error) {
 	defaultConfig := &serial.Config{
 		Name:        "/dev/serial0",
@@ -42,98 +43,117 @@ func New(conf *serial.Config) (*Lora, error) {
 	}
 
 	return &Lora{
-		port: port,
+		port:    port,
+		timeout: defaultConfig.ReadTimeout,
 	}, nil
 }
 
-func (l *Lora) tx(cmd string) (string, error) {
+func (l *Lora) txr(cmd string, lines int) (string, error) {
 	if _, err := l.port.Write(createCmd(cmd)); err != nil {
-		return "", fmt.Errorf("failed to write command %q with: %s", cmd, err)
+		return "", errors.Wrapf(err, "writing a command:%v", cmd)
 	}
+	return l.tr(lines)
+}
 
-	scanner := bufio.NewScanner(bufio.NewReader(l.port))
+func (l *Lora) tr(lines int) (string, error) {
+	reader := bufio.NewReader(l.port)
 	var resp string
-	for scanner.Scan() {
-		resp += scanner.Text()
-	}
+	start := time.Now()
+	for line := 0; line < lines; line++ {
+		for {
+			r, err := reader.ReadString('\n')
 
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("failed reading response: %s", err)
+			if err != nil {
+				if err == io.EOF { // The serial port has a max timeout of 25sec so we rely on the l.timeout.
+					continue
+				}
+				return "", errors.Wrap(err, "failed read")
+			}
+			if strings.HasPrefix(r, "ERROR") {
+				return "", errors.Errorf(r)
+			}
+			resp += r
+			if time.Since(start) > l.timeout {
+				return "", errors.Errorf("no response within:%v", l.timeout)
+			}
+			break
+		}
 	}
-	return resp, nil
+	return strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(resp), "\r"), "\n"), nil
 }
 
 //
 // System Commands
 //
 
-// Version get module version
+// Version get module version.
 func (l *Lora) Version() (string, error) {
-	return l.tx("version")
+	return l.txr("version", 1)
 }
 
-// Sleep enter sleep mode
+// Sleep enter sleep mode.
 func (l *Lora) Sleep() (string, error) {
-	return l.tx("sleep")
+	return l.txr("sleep", 1)
 }
 
-// Reset module or LoRaWAN stack
-// 0: reset and restart module
+// Wakeup to wake up the module.
+func (l *Lora) Wakeup() (string, error) {
+	return l.txr("wake", 1) // Any command will wake it up.
+}
+
+// Reset module or LoRaWAN stack.
+// 0: reset and restart module,
 // 1: reset LoRaWAN stack and the module will reload
-// LoRa configuration from EEPROM
+// LoRa configuration from EEPROM.
 func (l *Lora) Reset(mode int) (string, error) {
-	return l.tx(fmt.Sprintf("reset=%d", mode))
+	return l.txr(fmt.Sprintf("reset=%d", mode), 4)
 }
 
 // HardReset the module by reseting the hat pins.
 func (l *Lora) HardReset() (string, error) {
 	pin, err := rpi.OpenPin(rpi.GPIO17, gpio.ModeOutput)
 	if err != nil {
-		return "", fmt.Errorf("error opening pin err:%v", err)
+		return "", errors.Wrapf(err, "opening pin")
 	}
-
 	pin.Clear()
 	time.Sleep(10 * time.Millisecond)
 	pin.Set()
 	time.Sleep(2000 * time.Millisecond)
 	pin.Close()
 
-	scanner := bufio.NewScanner(bufio.NewReader(l.port))
-	var resp string
-	for scanner.Scan() {
-		resp += scanner.Text()
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("failed reading response: %s", err)
-	}
-
-	return resp, nil
+	return l.tr(4)
 }
 
 // Reload set LoRaWAN and LoraP2P configurations to default
 func (l *Lora) Reload() (string, error) {
-	return l.tx("reload")
+	return l.txr("reload", 4)
 }
 
 // GetMode get module mode
 func (l *Lora) GetMode() (string, error) {
-	return l.tx("mode")
+	return l.txr("mode", 1)
 }
 
 // SetMode set module to work for LoRaWAN or LoraP2P mode, defaults to 0
 func (l *Lora) SetMode(mode int) (string, error) {
-	return l.tx(fmt.Sprintf("mode=%d", mode))
+	resp, err := l.txr(fmt.Sprintf("mode=%d", mode), 4)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasSuffix(resp, "OK") {
+		return "", errors.Errorf("unexpected response:", resp)
+	}
+	return resp, nil
 }
 
 // GetRecvEx get RSSI & SNR report on receive flag (Enabled/Disabled).
 func (l *Lora) GetRecvEx() (string, error) {
-	return l.tx("recv_ex")
+	return l.txr("recv_ex", 1)
 }
 
 // SetRecvEx set RSSI & SNR report on receive flag (Enabled/Disabled).
 func (l *Lora) SetRecvEx(mode int) (string, error) {
-	return l.tx(fmt.Sprintf("recv_ex=%d", mode))
+	return l.txr(fmt.Sprintf("recv_ex=%d", mode), 1)
 }
 
 // Close the serial port.
@@ -147,180 +167,155 @@ func (l *Lora) Close() {
 // LoRaWAN commands
 //
 
-// SetConfig set LoRaWAN configurations
+// SetConfig set LoRaWAN configurations.
 func (l *Lora) SetConfig(config string) (string, error) {
-	return l.tx(fmt.Sprintf("set_config=%v", config))
+	return l.txr(fmt.Sprintf("set_config=%v", config), 1)
 }
 
-// GetConfig LoRaWAN configuration
+// GetConfig LoRaWAN configuration.
 func (l *Lora) GetConfig(key string) (string, error) {
-	return l.tx(fmt.Sprintf("get_config=%s", key))
+	return l.txr(fmt.Sprintf("get_config=%s", key), 1)
 }
 
 // GetBand LoRaWAN band region
 func (l *Lora) GetBand() (string, error) {
-	return l.tx("band")
+	return l.txr("band", 1)
 }
 
-// SetBand LoRaWAN band region
+// SetBand LoRaWAN band region.
 func (l *Lora) SetBand(band string) (string, error) {
-	return l.tx(fmt.Sprintf("band=%s", band))
+	return l.txr(fmt.Sprintf("band=%s", band), 1)
 }
 
 const (
-	// JoinSuccess successfull join.
-	JoinSuccess = "at+recv=3,0,0"
-	// JoinFail incorrect join config parameters.
-	JoinFail = "at+recv=4,0,0"
-	// JoinTimeout no response from a gateway.
-	JoinTimeout = "at+recv=6,0,0"
+	STATUS_RECV_DATA         = "at+recv=0,0,0"
+	STATUS_TX_COMFIRMED      = "at+recv=1,0,0"
+	STATUS_TX_UNCOMFIRMED    = "at+recv=2,0,0"
+	STATUS_JOINED_SUCCESS    = "at+recv=3,0,0"
+	STATUS_JOINED_FAILED     = "at+recv=4,0,0"
+	STATUS_TX_TIMEOUT        = "at+recv=5,0,0"
+	STATUS_RX2_TIMEOUT       = "at+recv=6,0,0"
+	STATUS_DOWNLINK_REPEATED = "at+recv=7,0,0"
+	STATUS_WAKE_UP           = "at+recv=8,0,0"
+	STATUS_P2PTX_COMPLETE    = "at+recv=9,0,0"
+	STATUS_UNKNOWN           = "at+recv=100,0,0"
 )
 
 // JoinOTAA join the configured network in OTAA mode.
-// The module doesn't accept any other command before it returns a response.
-// Response: JoinSuccess, JoinFail, JoinTimeout
-// Returns an error when the timeout argument expires.
-// This is as a fail safe so that the caller can reset the module
-// if it doesn't return anything for a long period.
-func (l *Lora) JoinOTAA(timeout time.Duration) (string, error) {
-	resp, err := l.tx("join=otaa")
+// The parent function needs to validate the response.
+// Valid responses:  STATUS_JOINED_SUCCESS, STATUS_JOINED_FAILED, STATUS_TX_TIMEOUT
+func (l *Lora) JoinOTAA() (string, error) {
+	resp, err := l.txr("join=otaa", 1)
 	if err != nil {
 		return "", err
 	}
 	if resp != OK {
 		return "", errors.Errorf("invalid join request response resp:%v", resp)
 	}
-	start := time.Now()
-	reader := bufio.NewReader(l.port)
-	for {
-		resp, err = reader.ReadString('\n')
-		resp = strings.TrimSuffix(strings.TrimSpace(resp), "\r")
-		if err == nil && resp != "" {
-			switch resp {
-			case JoinSuccess:
-				return JoinSuccess, nil
-			case JoinFail:
-				return JoinFail, nil
-			case JoinTimeout:
-				return JoinTimeout, nil
-			default:
-				return "", errors.Errorf("invalid join response resp:%v", resp)
-			}
-		}
-		if time.Since(start) > timeout {
-			return "", errors.New("no response after the set timeout")
-		}
-	}
+	// The module doesn't accept any other command before it returns a response
+	// so need to wait for it.
+	return l.tr(1)
 }
 
-// JoinABP join the configured network in ABP mode
+// JoinABP join the configured network in ABP mode.
 func (l *Lora) JoinABP() (string, error) {
-	return l.tx("join=abp")
+	return l.txr("join=abp", 1)
 }
 
-// Signal check the radio rssi, snr, update by latest received radio packet
+// Signal check the radio rssi, snr, update by latest received radio packet.
 func (l *Lora) Signal() (string, error) {
-	return l.tx("signal")
+	return l.txr("signal", 1)
 }
 
-// GetDataRate get next send data rate
+// GetDataRate get next send data rate.
 func (l *Lora) GetDataRate() (string, error) {
-	return l.tx("dr")
+	return l.txr("dr", 1)
 }
 
-// SetDataRate set next send data rate
+// SetDataRate set next send data rate.
 func (l *Lora) SetDataRate(datarate string) (string, error) {
-	return l.tx(fmt.Sprintf("dr=%s", datarate))
+	return l.txr(fmt.Sprintf("dr=%s", datarate), 1)
 }
 
-// GetLinkCnt get LoRaWAN uplink and downlink counter
+// GetLinkCnt get LoRaWAN uplink and downlink counter.
 func (l *Lora) GetLinkCnt() (string, error) {
-	return l.tx("link_cnt")
+	return l.txr("link_cnt", 1)
 }
 
-// SetLinkCnt set LoRaWAN uplink and downlink counter
+// SetLinkCnt set LoRaWAN uplink and downlink counter.
 func (l *Lora) SetLinkCnt(uplinkCnt, downlinkCnt float32) (string, error) {
-	return l.tx(fmt.Sprintf("link_cnt=%f,%f", uplinkCnt, downlinkCnt))
+	return l.txr(fmt.Sprintf("link_cnt=%f,%f", uplinkCnt, downlinkCnt), 1)
 }
 
 // GetABPInfo
 func (l *Lora) GetABPInfo() (string, error) {
-	return l.tx("abp_info")
+	return l.txr("abp_info", 1)
 }
 
-// Send send data to LoRaWAN network
+// Send send data to LoRaWAN network.
+// The parent function should check for:
+// STATUS_TX_UNCOMFIRMED when sending unconfirmed packets,
+// STATUS_TX_COMFIRMED when sending confirmed packets.
 func (l *Lora) Send(data string) (string, error) {
-	resp, err := l.tx(fmt.Sprintf("send=%s", data))
+	resp, err := l.txr(fmt.Sprintf("send=%s", data), 1)
 	if err != nil {
 		return "", err
 	}
 	if resp != OK {
 		return "", errors.Errorf("invalid send request response resp:%v", resp)
 	}
-
-	// Wait for the send success event.
-	resp, err = bufio.NewReader(l.port).ReadString('\n')
-	if err != nil {
-		if err == io.EOF {
-			return "", ErrTimeout
-		}
-		return "", fmt.Errorf("read err:%v", err)
-	}
-
-	resp = strings.TrimSpace(resp)
-	if resp != "at+recv=2,0,0" {
-		return "", fmt.Errorf("unexpected ack response:%v-", resp)
-	}
-	return resp, nil
+	// The module doesn't accept any other command before it returns a response
+	// so need to wait for it.
+	return l.tr(1)
 }
 
-// Recv receive event and data from LoRaWAN or LoRaP2P network
+// Recv receive event and data from LoRaWAN or LoRaP2P network.
 func (l *Lora) Recv(data string) (string, error) {
-	return l.tx(fmt.Sprintf("recv=%s", data))
+	return l.txr(fmt.Sprintf("recv=%s", data), 1)
 }
 
-// GetRfConfig get RF parameters
+// GetRfConfig get RF parameters.
 func (l *Lora) GetRfConfig() (string, error) {
-	return l.tx("rf_config")
+	return l.txr("rf_config", 1)
 }
 
 // SetRfConfig Set RF parameters
 func (l *Lora) SetRfConfig(parameters string) (string, error) {
-	return l.tx(fmt.Sprintf("rf_config=%s", parameters))
+	return l.txr(fmt.Sprintf("rf_config=%s", parameters), 1)
 }
 
 // Txc send LoraP2P message
 func (l *Lora) Txc(parameters string) (string, error) {
-	return l.tx(fmt.Sprintf("txc=%s", parameters))
+	return l.txr(fmt.Sprintf("txc=%s", parameters), 1)
 }
 
-// Rxc set module in LoraP2P receive mode
+// Rxc set module in LoraP2P receive mode.
 func (l *Lora) Rxc(enable int) (string, error) {
-	return l.tx(fmt.Sprintf("rxc=%d", enable))
+	return l.txr(fmt.Sprintf("rxc=%d", enable), 1)
 }
 
-// TxStop stops LoraP2P TX
+// TxStop stops LoraP2P TX.
 func (l *Lora) TxStop() (string, error) {
-	return l.tx("tx_stop")
+	return l.txr("tx_stop", 1)
 }
 
-// Stop LoraP2P RX
+// RxStop LoraP2P RX.
 func (l *Lora) RxStop() (string, error) {
-	return l.tx("rx_stop")
+	return l.txr("rx_stop", 1)
 }
 
 //
 // Radio commands
 //
 
-// GetStatus get radio statistics
+// GetRadioStatus get radio statistics.
 func (l *Lora) GetRadioStatus() (string, error) {
-	return l.tx("status")
+	return l.txr("status", 1)
 }
 
-// SetStatus clear radio statistics
+// ClearRadioStatus clear radio statistics.
 func (l *Lora) ClearRadioStatus() (string, error) {
-	return l.tx("status=0")
+	return l.txr("status=0", 1)
 }
 
 func createCmd(cmd string) []byte {
@@ -332,14 +327,14 @@ func createCmd(cmd string) []byte {
 // Peripheral commands
 //
 
-// GetUART get UART configurations
+// GetUART get UART configurations.
 func (l *Lora) GetUART() (string, error) {
-	return l.tx("uart")
+	return l.txr("uart", 1)
 }
 
-// SetUART set UART configurations
+// SetUART set UART configurations.
 func (l *Lora) SetUART(configuration string) (string, error) {
-	return l.tx(fmt.Sprintf("uart=%s", configuration))
+	return l.txr(fmt.Sprintf("uart=%s", configuration), 1)
 }
 
 func newConfig(config *serial.Config) config {

--- a/rak811.go
+++ b/rak811.go
@@ -210,7 +210,7 @@ func (l *Lora) JoinOTAA() (string, error) {
 		return "", err
 	}
 	if resp != OK {
-		return "", errors.Errorf("invalid join request response resp:%v", resp)
+		return "", errors.New(resp) // Convert the resp to an error so that the caller handle it properly.
 	}
 	// The module doesn't accept any other command before it returns a response
 	// so need to wait for it.
@@ -262,7 +262,7 @@ func (l *Lora) Send(data string) (string, error) {
 		return "", err
 	}
 	if resp != OK {
-		return "", errors.Errorf("invalid send request response resp:%v", resp)
+		return "", errors.New(resp) // Convert the resp to an error so that the caller handle it properly.
 	}
 	// The module doesn't accept any other command before it returns a response
 	// so need to wait for it.

--- a/rak811_test.go
+++ b/rak811_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestCreateCmd(t *testing.T) {
@@ -36,16 +35,13 @@ func TestCreateCmd(t *testing.T) {
 }
 
 func TestLora_Version(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK2.0.3.0\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK2.0.3.0"))
+	lora := newTestLora(fsp)
 
 	t.Run("get software version", func(t *testing.T) {
 		actual, err := lora.Version()
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(actual), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", actual, fsp.At())
@@ -55,14 +51,12 @@ func TestLora_Version(t *testing.T) {
 
 func TestLora_Sleep(t *testing.T) {
 	fsp := newFakeFakeSerialPort([]byte(OK))
-	lora := &Lora{
-		port: fsp,
-	}
+	lora := newTestLora(fsp)
 
 	t.Run("module enter sleep", func(t *testing.T) {
 		res, err := lora.Sleep()
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -71,15 +65,15 @@ func TestLora_Sleep(t *testing.T) {
 }
 
 func TestLora_Reset(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte(OK))
-	lora := &Lora{
-		port: fsp,
-	}
+	// The module firmware is broken and returns 4 lines instead of 1 so
+	// the reader needs to provide 4 lines.
+	fsp := newFakeFakeSerialPort([]byte(""), []byte(""), []byte(""), []byte(OK))
+	lora := newTestLora(fsp)
 
 	t.Run("reset module", func(t *testing.T) {
 		res, err := lora.Reset(0)
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -88,16 +82,15 @@ func TestLora_Reset(t *testing.T) {
 }
 
 func TestLora_Reload(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte(OK))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	// The module firmware is broken and returns 4 lines instead of 1 so
+	// the reader needs to provide 4 lines.
+	fsp := newFakeFakeSerialPort([]byte(""), []byte(""), []byte(""), []byte(OK))
+	lora := newTestLora(fsp)
 
 	t.Run("reload the default parameters", func(t *testing.T) {
 		res, err := lora.Reset(0)
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -106,16 +99,15 @@ func TestLora_Reload(t *testing.T) {
 }
 
 func TestLora_SetMode(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte(OK))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	// The module firmware is broken and returns 4 lines instead of 1 so
+	// the reader needs to provide 4 lines.
+	fsp := newFakeFakeSerialPort([]byte(""), []byte(""), []byte(""), []byte(OK))
+	lora := newTestLora(fsp)
 
 	t.Run("set module work on", func(t *testing.T) {
 		res, err := lora.SetMode(0)
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -125,15 +117,12 @@ func TestLora_SetMode(t *testing.T) {
 
 func TestLora_SetRecvEx(t *testing.T) {
 	fsp := newFakeFakeSerialPort([]byte(OK))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	lora := newTestLora(fsp)
 
 	t.Run("set enable or disable rssi and snr messages", func(t *testing.T) {
 		res, err := lora.SetRecvEx(0)
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -143,15 +132,12 @@ func TestLora_SetRecvEx(t *testing.T) {
 
 func TestLora_SetConfig(t *testing.T) {
 	fsp := newFakeFakeSerialPort([]byte(OK))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	lora := newTestLora(fsp)
 
 	t.Run("set enable or disable rssi and snr messages", func(t *testing.T) {
 		res, err := lora.SetConfig("EU868:20")
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -161,15 +147,12 @@ func TestLora_SetConfig(t *testing.T) {
 
 func TestLora_GetConfig(t *testing.T) {
 	fsp := newFakeFakeSerialPort([]byte(OK))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	lora := newTestLora(fsp)
 
 	t.Run("get lora configuration", func(t *testing.T) {
 		res, err := lora.GetConfig("dev_addr")
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -178,16 +161,13 @@ func TestLora_GetConfig(t *testing.T) {
 }
 
 func TestLora_GetBand(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OKEU868\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OKEU868"))
+	lora := newTestLora(fsp)
 
 	t.Run("get lora region", func(t *testing.T) {
 		res, err := lora.GetBand()
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -196,30 +176,24 @@ func TestLora_GetBand(t *testing.T) {
 }
 
 func TestLora_JoinOTAA(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte(OK+"\r\n"), []byte(JoinSuccess+"\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte(OK), []byte(STATUS_JOINED_SUCCESS))
+	lora := newTestLora(fsp)
 
 	t.Run("activation over the air", func(t *testing.T) {
-		res, err := lora.JoinOTAA(1 * time.Second)
+		res, err := lora.JoinOTAA()
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 
-		if bytes.Compare([]byte(JoinSuccess), fsp.At()) != 0 {
+		if bytes.Compare([]byte(STATUS_JOINED_SUCCESS), fsp.At()) != 0 {
 			t.Fatalf("got %q, want %q", res, fsp.At())
 		}
 	})
 }
 
 func TestLora_Signal(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK10 11\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK10 11"))
+	lora := newTestLora(fsp)
 
 	t.Run("signal from Lora gateway", func(t *testing.T) {
 		res, err := lora.Signal()
@@ -234,15 +208,12 @@ func TestLora_Signal(t *testing.T) {
 
 func TestLora_GetDataRate(t *testing.T) {
 	fsp := newFakeFakeSerialPort([]byte(OK))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	lora := newTestLora(fsp)
 
 	t.Run("change next data rate", func(t *testing.T) {
 		res, err := lora.SetDataRate("EU868")
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -251,16 +222,13 @@ func TestLora_GetDataRate(t *testing.T) {
 }
 
 func TestLora_GetLinkCnt(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK1,2\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK1,2"))
+	lora := newTestLora(fsp)
 
 	t.Run("get lora link info", func(t *testing.T) {
 		res, err := lora.SetLinkCnt(1.0, 2.0)
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -269,16 +237,13 @@ func TestLora_GetLinkCnt(t *testing.T) {
 }
 
 func TestLora_GetABPInfo(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK1,2,64,32\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK1,2,64,32"))
+	lora := newTestLora(fsp)
 
 	t.Run("abp info query", func(t *testing.T) {
 		res, err := lora.GetABPInfo()
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -287,11 +252,8 @@ func TestLora_GetABPInfo(t *testing.T) {
 }
 
 func TestLora_Send(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte(OK+"\r\n"), []byte("at+recv=2,0,0\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte(OK), []byte("at+recv=2,0,0"))
+	lora := newTestLora(fsp)
 
 	t.Run("send packet string", func(t *testing.T) {
 		res, err := lora.Send("0,1,DEADBEFF")
@@ -305,16 +267,13 @@ func TestLora_Send(t *testing.T) {
 }
 
 func TestLora_Recv(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK1,2\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK1,2"))
+	lora := newTestLora(fsp)
 
 	t.Run("receive the module data", func(t *testing.T) {
-		res, err := lora.Recv("STATUS_TX_CONFIRMED,10\r\n")
+		res, err := lora.Recv("STATUS_TX_CONFIRMED,10")
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -323,16 +282,13 @@ func TestLora_Recv(t *testing.T) {
 }
 
 func TestLora_GetRfConfig(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK868100000,12,0,1,8,20\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK868100000,12,0,1,8,20"))
+	lora := newTestLora(fsp)
 
 	t.Run("get lorap2p configuration", func(t *testing.T) {
 		res, err := lora.GetRfConfig()
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -342,14 +298,12 @@ func TestLora_GetRfConfig(t *testing.T) {
 
 func TestLora_Txc(t *testing.T) {
 	fsp := newFakeFakeSerialPort([]byte(OK))
-	lora := &Lora{
-		port: fsp,
-	}
+	lora := newTestLora(fsp)
 
 	t.Run("set lorap2p tx continues", func(t *testing.T) {
 		res, err := lora.Txc("1,10,64")
 		if err != nil {
-			t.Errorf("error %v", err)
+			t.Fatalf("error %v", err)
 		}
 		if bytes.Compare([]byte(res), fsp.At()) != 0 {
 			t.Errorf("got %q, want %q", res, fsp.At())
@@ -358,11 +312,8 @@ func TestLora_Txc(t *testing.T) {
 }
 
 func TestLora_GetRadioStatus(t *testing.T) {
-	fsp := newFakeFakeSerialPort([]byte("OK1,2,3,4,5,6,7\r\n"))
-
-	lora := &Lora{
-		port: fsp,
-	}
+	fsp := newFakeFakeSerialPort([]byte("OK1,2,3,4,5,6,7"))
+	lora := newTestLora(fsp)
 
 	t.Run("get the radio statistics", func(t *testing.T) {
 		res, err := lora.GetRadioStatus()
@@ -384,22 +335,16 @@ func newFakeFakeSerialPort(data ...[]byte) *FakeSerialPort {
 type FakeSerialPort struct {
 	responses [][]byte // Each element is returns as a separate response.
 	current   []byte
-	next      bool
 }
 
 func (f *FakeSerialPort) Read(p []byte) (n int, err error) {
 	if len(f.responses) == 0 {
-		return 0, io.EOF
+		return 0, nil
 	}
 
-	if f.next {
-		f.next = false
-		return 0, io.EOF
-	}
-	f.current = f.responses[0]
+	f.current = append(f.responses[0], []byte("\r\n")...)
 	copy(p, f.current)
 	f.responses = f.responses[1:]
-	f.next = true
 	return len(f.current), nil
 }
 
@@ -413,4 +358,12 @@ func (*FakeSerialPort) Close() error {
 
 func (f FakeSerialPort) At() []byte {
 	return []byte(strings.TrimSuffix(string(f.current), "\r\n"))
+}
+
+func newTestLora(fsp io.ReadWriteCloser) *Lora {
+	return &Lora{
+		port:    fsp,
+		timeout: defaultConfig.ReadTimeout,
+	}
+
 }


### PR DESCRIPTION
We can't rely on EOF as some commands return more than a single line.
For example  with  `(l *Lora) Send(data string)` if you rely on EOF
sometime it will return `OK` and sometimes it will return `OKat+recv=2,0,0`
(the second part is the ack package). That is way it is important to
know exactly how many lines want to read from the output.
I spoke with one of the pi hat developers and he confirmed that they are
doing the same thing - reading a given number of lines based on the
command.
The PR also adds a global timeout as the serial library has a max
timeout of 25 seconds even when opening the port with a higher timeout
in the cofig settings.

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>